### PR TITLE
2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: bash
+dist: xenial
 sudo: enabled
 branches:
   only:
@@ -33,6 +34,12 @@ matrix:
     - name: "Debian (buster)"
       env:
         - DISTRO='debian:buster'
+    - name: "Fedora (latest)"
+      env:
+        - DISTRO='fedora:latest'
+    - name: "Fedora (rawhide)"
+      env:
+        - DISTRO='fedora:rawhide'
 
 before_install:
   - docker pull ${DISTRO}
@@ -53,7 +60,10 @@ install:
 
 script:
   - docker exec recap_on_${DISTRO/:/_} bash -c 'recap --version'
+  - docker exec recap_on_${DISTRO/:/_} bash -c 'recaplog --version'
   - docker exec recap_on_${DISTRO/:/_} /recap/tests/run_recap.sh
   - docker exec recap_on_${DISTRO/:/_} bash -c 'ls -tr /var/log/recap/*log | xargs tail -v -n+0'
+  - docker exec recap_on_${DISTRO/:/_} /recap/tests/run_recaplog.sh
+  - docker exec recap_on_${DISTRO/:/_} bash -c 'tail -v -n+0 /var/log/recap/recaplog.log'
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
-## [2.0.2] - 2018-02-25
+## [2.1.0] - 2019-04-12
+- Remove signal `17` in `recaplog` [(#208)][208]
+- Use posix for better regex support in el6 [(#207)][207]
+- Fix hostname definition [(#213)][213]
+- Add system lock plugin [(#189)][189]
+
+## [2.0.2] - 2019-02-25
 - Dynamically find CPU field to sort top CPU report [(#203)][203]
 
-## [2.0.1] - 2018-02-05
+## [2.0.1] - 2019-02-05
 - Fix bug related to DESTDIR included in recap script [(#195)][195] [(#198)][198].
 
-## [2.0.0] - 2018-01-22
+## [2.0.0] - 2019-01-22
 - Add plugin support [(#155)][155].
   - Split recap functionality between core functions and plugins.
   - Plugins are not enabled by default on this version.
@@ -213,9 +219,13 @@ All notable changes to this project will be documented in this file.
 [170]: https://github.com/rackerlabs/recap/issues/170
 [174]: https://github.com/rackerlabs/recap/issues/174
 [175]: https://github.com/rackerlabs/recap/issues/175
+[189]: https://github.com/rackerlabs/recap/issues/189
 [195]: https://github.com/rackerlabs/recap/issues/195
 [198]: https://github.com/rackerlabs/recap/issues/198
 [203]: https://github.com/rackerlabs/recap/issues/203
+[207]: https://github.com/rackerlabs/recap/issues/207
+[208]: https://github.com/rackerlabs/recap/issues/208
+[213]: https://github.com/rackerlabs/recap/pull/213
 
 <!---
 # One-liners to help generate content for CHANGELOG.md

--- a/debian/recap.lintian-overrides
+++ b/debian/recap.lintian-overrides
@@ -10,3 +10,4 @@ recap: script-not-executable usr/lib/recap/plugins-available/docker_top
 recap: script-not-executable usr/lib/recap/plugins-available/http_status
 recap: script-not-executable usr/lib/recap/plugins-available/kernel_cmd
 recap: script-not-executable usr/lib/recap/plugins-available/redis
+recap: script-not-executable usr/lib/recap/plugins-available/system_locks

--- a/src/plugins/system_locks
+++ b/src/plugins/system_locks
@@ -18,12 +18,23 @@
 #
 #
 
-print_<plugin_name>() {
+print_system_locks() {
   local LOGFILE="$1"
   local plugin_name=${FUNCNAME[0]/print_/}
   log INFO "Starting '${plugin_name}' report - ${LOGFILE##*/}"
-  ## Write your plugin here, redirect output to ${LOGFILE}
-  # echo hello from <plugin_name> >> "${LOGFILE}"
-  ## End of your plugin
+  local lslocks=$( type -p lslocks )
+  local options=${PLUGIN_OPTS_SYSTEM_LOCKS_OPTS:-"--notruncate"}
+  local timeout=${PLUGIN_OPTS_SYSTEM_LOCKS_TIMEOUT:-"5"}
+
+  if [[ -z "${lslocks}" ]]; then
+    echo "lslocks is unavailable, fallback to /proc/locks..." >> "${LOGFILE}"
+    timeout "${timeout}" \
+      cat /proc/locks $>> "${LOGFILE}"
+  else
+    timeout "${timeout}" \
+      "${lslocks}" "${options}" &>> "${LOGFILE}"
+  fi
+
   log INFO "Ended '${plugin_name}' report"
 }
+

--- a/src/recap
+++ b/src/recap
@@ -26,7 +26,7 @@
 #~
 
 ## Version
-declare -r _VERSION='2.0.2'
+declare -r _VERSION='2.1.0'
 
 ## Default settings(can *NOT* be overridden in config file)
 declare -r DATE=$( date +%F_%T )
@@ -545,7 +545,16 @@ if [[ "$(id -u)" != "0" ]]; then
 fi
 
 # Grab the server's host name
-HOSTNAME="$( hostname )"
+HOSTNAME="$( hostnamectl --static 2>/dev/null ||
+             hostname 2>/dev/null ||
+             echo 'Unknown' )"
+
+# Workaround for ubuntu14 as --static has no effect when printing values
+if grep -q 'hostname:' <<<"${HOSTNAME}"; then
+  HOSTNAME=$( awk -F: \
+              '/hostname/ {gsub("\\s*","",$2)
+              print $2}' <<<"${HOSTNAME}" )
+fi
 
 # Start logging
 log INFO "${banner_start}"

--- a/src/recaplog
+++ b/src/recaplog
@@ -29,7 +29,7 @@
 #~
 
 ## Version
-declare -r _VERSION='2.0.2'
+declare -r _VERSION='2.1.0'
 
 ## Default settings
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
@@ -133,7 +133,7 @@ get_report_names_of_day() {
   log INFO "Finding reports from: ${day}"
   reports=(
     $( ls -1 "${BASEDIR}" 2>/dev/null |
-         awk -F. \
+         awk --posix -F. \
          '
            /'${day}'-[0-9]{6}\.log$/ {sub("_'${day}'-[0-9]{6}","",$1); print $1}
          ' |
@@ -243,7 +243,7 @@ recaploglock() {
     log ERROR "$( basename $0 ) ($$): Lock File exists - exiting"
     exit 1
   else
-    trap 'exit 2' 1 2 15 17 23
+    trap 'exit 2' 1 2 15 23
     trap 'cleanup' EXIT
     log INFO "$( basename $0 ) ($$): Created lock file: ${LOCKFILE}"
   fi

--- a/src/recaptool
+++ b/src/recaptool
@@ -31,7 +31,7 @@
 #~
 
 ## Version
-declare -r _VERSION='2.0.2'
+declare -r _VERSION='2.1.0'
 
 ## Default settings
 BASEDIR="/var/log/recap"

--- a/tests/install_deps.sh
+++ b/tests/install_deps.sh
@@ -16,7 +16,7 @@ packages=(
           )
 
 case ${DISTRO} in
-  centos*)
+  centos*|fedora*)
     packages+=("iproute")
     yum install ${packages[@]} -y || exit $?
     ;;

--- a/tests/run_recaplog.sh
+++ b/tests/run_recaplog.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Get full path to recaplog
+recaplog_path=$(type -p recaplog)
+
+# Insert 'set -e' on line 2 of recaplog to exit after any failure
+sed -i "2iset -e" "${recaplog_path}";
+
+# Save debugging info and record the status of the recaplog run
+debug_info=$(bash -x "${recaplog_path}" 2>&1)
+stat=$?
+
+# Save the debugging info that occurred right before the cleanup operation
+cleanup_trigger=$(echo "${debug_info}" | grep -P "^\+\s+cleanup" -B 20)
+
+# Show the info that triggered the cleanup if there was an error running recaplog
+if [[ ${stat} -ne 0 ]]; then
+  echo "An error occurred while doing the following:"
+  echo "${cleanup_trigger}"
+fi
+
+# Exit with the status of the recaplog run
+exit ${stat}


### PR DESCRIPTION
- New upstream version 2.1.0
- Override lintian warning: script-not-executable 

Hi @jkirk!

I'm creating this PR to have the base for the latest upstream version `2.1.0`. Debian tracker is showing this version is now available https://tracker.debian.org/pkg/recap but I don't see any bug created for it, for that reason this PR is missing a changelog update.

Even when at this moment a new package may not be required, it may be useful for anyone wanting to build a new package, then this PR should help with that.

Feel free to close/merge/keep it as you see is the best.

Thanks!